### PR TITLE
Add error handling and hard limit for numerical rows for scatterplot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+playground/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { Histogram }  from './components/graph/Histogram/Histogram';
 import { Scatterplot }  from './components/graph/Scatterplot/Scatterplot';
 import { CorrelationMatrix }  from './components/graph/CorrelationMatrix/CorrelationMatrix';
-import { inferSchema, Schema } from './utils/schema';
+import { DataType, inferSchema, Schema } from './utils/schema';
 import { classNames } from './utils/classnames';
 import { transpose } from './utils/transform';
 import Navbar from './components/navigation/Navbar';
@@ -10,6 +10,7 @@ import NoDatasetSelected from './components/navigation/NoDatasetSelected';
 import Dataloader from './components/data/Dataloader';
 import DataCard from './components/data/DataCard';
 import { ChartBarIcon, CircleStackIcon, CubeTransparentIcon, CalculatorIcon } from '@heroicons/react/24/outline'
+import NotEnoughNumericalColumns from './components/navigation/NotEnoughNumericalColumns';
 
 export default function App() {
   const elementRef = useRef<HTMLDivElement | null>(null)
@@ -105,7 +106,15 @@ export default function App() {
             </>
           }
           {currentTab === 'Histogram' && (schema.length > 0 ? <Histogram height={450} width={width} matrix={matrix} keys={keys} schema={schema}/> : <NoDatasetSelected/>)}
-          {currentTab === 'Scatter Plot' && (schema.length > 0 ? <Scatterplot height={450} width={width} matrix={matrix} keys={keys} schema={schema}/> : <NoDatasetSelected/>)}
+          {currentTab === 'Scatter Plot' && 
+            (schema.length > 0 ?
+              schema.filter(s => s.type == DataType.Number).length > 1 ?
+                <Scatterplot height={450} width={width} matrix={matrix} keys={keys} schema={schema}/>
+                : <NotEnoughNumericalColumns/>
+            :
+              <NoDatasetSelected/>
+            )
+          }
           {currentTab === 'Correlation Matrix' && (schema.length > 0 ? <CorrelationMatrix height={450} width={width} matrix={matrix} keys={keys} schema={schema}/> : <NoDatasetSelected/>)}
         </div>
     </div>

--- a/src/components/graph/Scatterplot/Scatterplot.tsx
+++ b/src/components/graph/Scatterplot/Scatterplot.tsx
@@ -5,6 +5,7 @@ import { transformOps } from "../../../utils/transform";
 import { Tooltip, InteractionData } from './Tooltip';
 import { AxisBottom } from './AxisBottom';
 import { AxisLeft } from './AxisLeft';
+import TooManyRows, { MAX_ROWS_TO_DISPLY } from '../../navigation/TooManyRows';
 
 enum ScatterTransformType {
   None = "none",
@@ -173,132 +174,137 @@ export const Scatterplot = ({ width, height, matrix, schema, keys } : Scatterplo
 
   return (
     <div id='scatterplot' className='mx-auto'>
-      <div className="relative my-5">
-          <svg width={width} height={height}>
-            <g
-              width={boundsWidth}
-              height={boundsHeight}
-              transform={`translate(${[margin.left, margin.top].join(",")})`}
-            >
-              <AxisLeft yScale={yScale} pixelsPerTick={40} width={boundsWidth} />
-              <g transform={`translate(0, ${boundsHeight})`}>
-                <AxisBottom
-                  xScale={xScale}
-                  pixelsPerTick={40}
+      {
+        allShapes.length > MAX_ROWS_TO_DISPLY ? <TooManyRows rows={allShapes.length} /> :
+        <>
+          <div className="relative my-5">
+              <svg width={width} height={height}>
+                <g
+                  width={boundsWidth}
                   height={boundsHeight}
-                />
-              </g>
-              {allShapes}
-            </g>
-          </svg>
-          <div
-            style={{
-              width: boundsWidth,
-              height: boundsHeight,
-              position: "absolute",
-              top: 0,
-              left: 0,
-              pointerEvents: "none",
-              marginLeft: margin.left,
-              marginTop: margin.top,
-            }}
-          >
-            <Tooltip interactionData={hovered} />
+                  transform={`translate(${[margin.left, margin.top].join(",")})`}
+                >
+                  <AxisLeft yScale={yScale} pixelsPerTick={40} width={boundsWidth} />
+                  <g transform={`translate(0, ${boundsHeight})`}>
+                    <AxisBottom
+                      xScale={xScale}
+                      pixelsPerTick={40}
+                      height={boundsHeight}
+                    />
+                  </g>
+                  {allShapes}
+                </g>
+              </svg>
+              <div
+                style={{
+                  width: boundsWidth,
+                  height: boundsHeight,
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  pointerEvents: "none",
+                  marginLeft: margin.left,
+                  marginTop: margin.top,
+                }}
+              >
+                <Tooltip interactionData={hovered} />
+              </div>
           </div>
-      </div>
-      <div key='x'>
-          <span>X Axis:</span>
-          {
-              keys.map((key: string, idx: number ) =>
-                  <button
-                      key={key}
-                      disabled={schema[idx].type === DataType.Categorical}
-                      className={`
-                        border ${idx === xAxisIdx ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
-                        m-1 rounded-md px-2 py-1 text-sm
-                        ${idx === xAxisIdx ? 'bg-indigo-500' : 'text-indigo-500'}
-                        ${idx === xAxisIdx ? 'opacity-100' : 'opacity-70'}
-                        ${schema[idx].type === DataType.Categorical ? 'cursor-not-allowed border-gray-400 bg-gray-200 opacity-50' : ''}`
-                      }
-                      onClick={() => {
-                          setXAxisIdx(idx)
-                          setXTransform(ScatterTransformType.None)
+          <div key='x'>
+              <span>X Axis:</span>
+              {
+                  keys.map((key: string, idx: number ) =>
+                      <button
+                          key={key}
+                          disabled={schema[idx].type === DataType.Categorical}
+                          className={`
+                            border ${idx === xAxisIdx ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
+                            m-1 rounded-md px-2 py-1 text-sm
+                            ${idx === xAxisIdx ? 'bg-indigo-500' : 'text-indigo-500'}
+                            ${idx === xAxisIdx ? 'opacity-100' : 'opacity-70'}
+                            ${schema[idx].type === DataType.Categorical ? 'cursor-not-allowed border-gray-400 bg-gray-200 opacity-50' : ''}`
+                          }
+                          onClick={() => {
+                              setXAxisIdx(idx)
+                              setXTransform(ScatterTransformType.None)
+                            }
                         }
-                    }
-                  >
-                      {key}
-                  </button>
-              )
-          }
-      </div>
-      <div>
-        <span>Transform:</span>
-        {
-            [ScatterTransformType.None, ScatterTransformType.Log10, ScatterTransformType.Ln].map((key) => (
-              <button
-                key={key}
-                className={`
-                  border ${xTransform === key ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
-                  m-1 rounded-md px-2 py-1 text-sm
-                  ${xTransform === key ? 'bg-indigo-500' : 'text-indigo-500'}
-                  ${xTransform === key ? 'opacity-100' : 'opacity-70'}`
-                }
-                disabled={schema[xAxisIdx].type === 'categorical'}
-                onClick={() => handleTransformX(key)}
-              >
-                {key}
-              </button>
-            )
-          )
-        }
-        <span className="ml-2 text-red-400">{errorMessageX}</span>
-      </div>
-      <div className="mt-4" key='y'>
-          <span>Y Axis: </span>
-          {
-              keys.map((key: string, idx: number ) =>
+                      >
+                          {key}
+                      </button>
+                  )
+              }
+          </div>
+          <div>
+            <span>Transform:</span>
+            {
+                [ScatterTransformType.None, ScatterTransformType.Log10, ScatterTransformType.Ln].map((key) => (
                   <button
-                      key={key}
-                      className={`
-                        border ${idx === yAxisIdx ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
-                        m-1 rounded-md px-2 py-1 text-sm
-                        ${idx === yAxisIdx ? 'bg-indigo-500' : 'text-indigo-500'}
-                        ${idx === yAxisIdx ? 'opacity-100' : 'opacity-70'}
-                        ${schema[idx].type === DataType.Categorical ? 'cursor-not-allowed border-gray-400 bg-gray-200 opacity-50' : ''}`
-                      }
-                      disabled={schema[xAxisIdx].type === 'categorical'}
-                      onClick={() => {
-                        setYAxisIdx(idx)
-                        setYTransform(ScatterTransformType.None)
-                      }
+                    key={key}
+                    className={`
+                      border ${xTransform === key ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
+                      m-1 rounded-md px-2 py-1 text-sm
+                      ${xTransform === key ? 'bg-indigo-500' : 'text-indigo-500'}
+                      ${xTransform === key ? 'opacity-100' : 'opacity-70'}`
                     }
+                    disabled={schema[xAxisIdx].type === 'categorical'}
+                    onClick={() => handleTransformX(key)}
                   >
-                      {key}
+                    {key}
                   </button>
+                )
               )
-          }
-      </div>
-      <div>
-        <span>Transform:</span>
-        {
-            [ScatterTransformType.None, ScatterTransformType.Log10, ScatterTransformType.Ln].map((key) => (
-              <button
-                key={key}
-                className={`
-                  border ${yTransform === key ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
-                  m-1 rounded-md px-2 py-1 text-sm
-                  ${yTransform === key ? 'bg-indigo-500' : 'text-indigo-500'}
-                  ${yTransform === key ? 'opacity-100' : 'opacity-70'}`
-                }
-                onClick={() => handleTransformY(key)}
-              >
-                {key}
-              </button>
-            )
-          )
-        }
-        <span className="ml-2 text-red-400">{errorMessageY}</span>
-      </div>
+            }
+            <span className="ml-2 text-red-400">{errorMessageX}</span>
+          </div>
+          <div className="mt-4" key='y'>
+              <span>Y Axis: </span>
+              {
+                  keys.map((key: string, idx: number ) =>
+                      <button
+                          key={key}
+                          className={`
+                            border ${idx === yAxisIdx ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
+                            m-1 rounded-md px-2 py-1 text-sm
+                            ${idx === yAxisIdx ? 'bg-indigo-500' : 'text-indigo-500'}
+                            ${idx === yAxisIdx ? 'opacity-100' : 'opacity-70'}
+                            ${schema[idx].type === DataType.Categorical ? 'cursor-not-allowed border-gray-400 bg-gray-200 opacity-50' : ''}`
+                          }
+                          disabled={schema[xAxisIdx].type === 'categorical'}
+                          onClick={() => {
+                            setYAxisIdx(idx)
+                            setYTransform(ScatterTransformType.None)
+                          }
+                        }
+                      >
+                          {key}
+                      </button>
+                  )
+              }
+          </div>
+          <div>
+            <span>Transform:</span>
+            {
+                [ScatterTransformType.None, ScatterTransformType.Log10, ScatterTransformType.Ln].map((key) => (
+                  <button
+                    key={key}
+                    className={`
+                      border ${yTransform === key ? 'bg-indigo-500 text-white' : 'border-indigo-500'}
+                      m-1 rounded-md px-2 py-1 text-sm
+                      ${yTransform === key ? 'bg-indigo-500' : 'text-indigo-500'}
+                      ${yTransform === key ? 'opacity-100' : 'opacity-70'}`
+                    }
+                    onClick={() => handleTransformY(key)}
+                  >
+                    {key}
+                  </button>
+                )
+              )
+            }
+            <span className="ml-2 text-red-400">{errorMessageY}</span>
+          </div>
+        </>
+      }
     </div>
   );
 };

--- a/src/components/navigation/NotEnoughNumericalColumns.tsx
+++ b/src/components/navigation/NotEnoughNumericalColumns.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const NotEnoughNumericalColumns: React.FC = () => {
+    return (
+        <div className='mt-4 text-gray-600'>
+            Not enough numerical columns found. Load a CSV file with <span className="font-semibold">at least 2</span> numerical columns in the <span className='font-semibold'>Datasets</span> tab.
+        </div>
+    );
+};
+
+export default NotEnoughNumericalColumns;

--- a/src/components/navigation/TooManyRows.tsx
+++ b/src/components/navigation/TooManyRows.tsx
@@ -1,0 +1,15 @@
+export const MAX_ROWS_TO_DISPLY = 100000;
+
+type TooManyRowsProps = {
+    rows: number;
+};
+
+const TooManyRows = ({rows}: TooManyRowsProps) => {
+    return (
+        <div className='mt-4 text-gray-600'>
+            Your CSV file has too many rows ({rows}). Please upload a file with less than {MAX_ROWS_TO_DISPLY} rows.
+        </div>
+    );
+};
+
+export default TooManyRows;


### PR DESCRIPTION
- Previously the scatterplot was erroring out if the CSV file contained less than 2 numerical columns
  - Now the error message will be shown if there's less than 2 numerical columns 
- Scatterplot will slow down significantly if a very large number of circles are drawn
  - Add a hard limit for the scatterplot display
  - Sampling/Filtering will be implemented in follow-up PRs 
  